### PR TITLE
Use TaskCompletionSource instead of ManualResetEvent

### DIFF
--- a/src/Xamarin.Social.iOS/Services/Twitter5Service.cs
+++ b/src/Xamarin.Social.iOS/Services/Twitter5Service.cs
@@ -166,7 +166,7 @@ namespace Xamarin.Social.Services
 			store.RequestAccess (at, (granted, error) => {
 				if (granted) {
 					var accounts = store.FindAccounts (at)
-						.Select (a => new ACAccountWrapper (a, store))
+						.Select (a => (Account) new ACAccountWrapper (a, store))
 						.ToList ();
 
 					tcs.SetResult (accounts);


### PR DESCRIPTION
Avoid blocking a thread pool thread by using `TaskCompletionSource` to
wait for account retrieval and response.

This commit is licensed under MIT/X11.
