### PR TITLE
Implement iOS 6 Social.framework providers

### DIFF
--- a/src/Xamarin.Social.iOS/Services/Facebook6Service.cs
+++ b/src/Xamarin.Social.iOS/Services/Facebook6Service.cs
@@ -1,0 +1,31 @@
+using System;
+using MonoTouch.Accounts;
+using MonoTouch.Social;
+using Xamarin.Auth;
+
+namespace Xamarin.Social.Services
+{
+	public class Facebook6Service : SocialService
+	{
+		public string FacebookAppId { get; set; }
+		public ACFacebookAudience Audience { get; set; }
+		public string Scope { get; set; }
+
+		protected override AccountStoreOptions AccountStoreOptions {
+			get {
+				var options = new AccountStoreOptions {
+					FacebookAppId = FacebookAppId
+				};
+
+				options.SetPermissions (Audience, Scope);
+				return options;
+			}
+		}
+
+		public Facebook6Service ()
+			: base ("Facebook", "Facebook", SLServiceKind.Facebook, ACAccountType.Facebook)
+		{
+			Audience = ACFacebookAudience.Everyone;
+		}
+	}
+}

--- a/src/Xamarin.Social.iOS/Services/Facebook6Service.cs
+++ b/src/Xamarin.Social.iOS/Services/Facebook6Service.cs
@@ -5,7 +5,7 @@ using Xamarin.Auth;
 
 namespace Xamarin.Social.Services
 {
-	public class Facebook6Service : SocialService
+	public class Facebook6Service : OSSocialService
 	{
 		public string FacebookAppId { get; set; }
 		public ACFacebookAudience Audience { get; set; }

--- a/src/Xamarin.Social.iOS/Services/OSSocialService.cs
+++ b/src/Xamarin.Social.iOS/Services/OSSocialService.cs
@@ -15,12 +15,12 @@ namespace Xamarin.Social.Services
 	/// <summary>
 	/// A base service for Social.framework family of services.
 	/// </summary>
-	public abstract class SocialService : Service
+	public abstract class OSSocialService : Service
 	{
 		private SLServiceKind kind;
 		private NSString accountTypeIdentifier;
 
-		public SocialService (string serviceId, string title, SLServiceKind kind, NSString accountTypeIdentifier)
+		public OSSocialService (string serviceId, string title, SLServiceKind kind, NSString accountTypeIdentifier)
 			: base (serviceId, title)
 		{
 			this.kind = kind;

--- a/src/Xamarin.Social.iOS/Services/OSSocialService.cs
+++ b/src/Xamarin.Social.iOS/Services/OSSocialService.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Social.Services
 
 			public override void AddMultipartData (string name, System.IO.Stream data, string mimeType, string filename)
 			{
-				request.AddMultipartData (NSData.FromStream (data), name, mimeType, string.Empty);
+				request.AddMultipartData (NSData.FromStream (data), name, mimeType, filename);
 			}
 
 			public override Task<Response> GetResponseAsync (CancellationToken cancellationToken)

--- a/src/Xamarin.Social.iOS/Services/SocialService.cs
+++ b/src/Xamarin.Social.iOS/Services/SocialService.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
+using MonoTouch.Accounts;
+using MonoTouch.Foundation;
+using MonoTouch.Social;
+using MonoTouch.UIKit;
+using Xamarin.Auth;
+
+namespace Xamarin.Social.Services
+{
+	/// <summary>
+	/// A base service for Social.framework family of services.
+	/// </summary>
+	public abstract class SocialService : Service
+	{
+		private SLServiceKind kind;
+		private NSString accountTypeIdentifier;
+
+		public SocialService (string serviceId, string title, SLServiceKind kind, NSString accountTypeIdentifier)
+			: base (serviceId, title)
+		{
+			this.kind = kind;
+			this.accountTypeIdentifier = accountTypeIdentifier;
+		}
+
+		#region Share
+
+		public override UIViewController GetShareUI (Item item, Action<ShareResult> completionHandler)
+		{
+			//
+			// Get the native UI
+			//
+			var vc = SLComposeViewController.FromService (kind);
+
+			vc.CompletionHandler = (result) => {
+				var shareResult = result == SLComposeViewControllerResult.Done ? ShareResult.Done : ShareResult.Cancelled;
+				completionHandler (shareResult);
+			};
+
+			vc.SetInitialText (item.Text);
+
+			foreach (var image in item.Images) {
+				vc.AddImage (image.Image);
+			}
+
+			foreach (var link in item.Links) {
+				vc.AddUrl (new NSUrl (link.AbsoluteUri));
+			}
+
+			return vc;
+		}
+
+		public override Task ShareItemAsync (Item item, Account account, CancellationToken cancellationToken)
+		{
+			throw new NotSupportedException ("Sharing items without a GUI is not supported. Please use GetShareUI instead.");
+		}
+
+		#endregion
+
+
+		#region Low-level Requests
+
+		class SocialRequest : Request
+		{
+			SLRequest request;
+
+			public SocialRequest (SLServiceKind kind, string method, Uri url, IDictionary<string, string> parametrs, Account account)
+				: base (method, url, parametrs, account)
+			{
+				var ps = new NSMutableDictionary ();
+				if (parametrs != null) {
+					foreach (var p in parametrs) {
+						ps.SetValueForKey (new NSString (p.Value), new NSString (p.Key));
+					}
+				}
+
+				var m = SLRequestMethod.Get;
+				switch (method.ToLowerInvariant()) {
+					case "get":
+					m = SLRequestMethod.Get;
+					break;
+					case "post":
+					m = SLRequestMethod.Post;
+					break;
+					case "delete":
+					m = SLRequestMethod.Delete;
+					break;
+					default:
+					throw new NotSupportedException ("Social framework does not support the HTTP method '" + method + "'");
+				}
+
+				request = SLRequest.Create (kind, m, new NSUrl (url.AbsoluteUri), ps);
+
+				Account = account;
+			}
+
+			public override Account Account {
+				get {
+					return base.Account;
+				}
+				set {
+					base.Account = value;
+
+					if (request != null) {
+						if (value == null) {
+							// Don't do anything, not supported
+						}
+						else if (value is ACAccountWrapper) {
+							request.Account = ((ACAccountWrapper)value).ACAccount;
+						}
+						else {
+							throw new NotSupportedException ("Account type '" + value.GetType().FullName + "'not supported");
+						}
+					}
+				}
+			}
+
+			public override void AddMultipartData (string name, System.IO.Stream data, string mimeType, string filename)
+			{
+				request.AddMultipartData (NSData.FromStream (data), name, mimeType, string.Empty);
+			}
+
+			public override Task<Response> GetResponseAsync (CancellationToken cancellationToken)
+			{
+				var tcs = new TaskCompletionSource<Response> ();
+
+				cancellationToken.Register (() => tcs.TrySetCanceled ());
+
+				request.PerformRequest ((resposeData, urlResponse, err) => {
+					Response result = null;
+					try {
+						if (err != null)
+							throw new Exception (err.LocalizedDescription);
+
+						result = new FoundationResponse (resposeData, urlResponse);
+					} catch (Exception ex) {
+						tcs.TrySetException (ex);
+						return;
+					}
+
+					tcs.TrySetResult (result);
+				});
+
+				return tcs.Task;
+			}
+		}
+
+		public override Request CreateRequest (string method, Uri url, IDictionary<string, string> paramters, Account account)
+		{
+			return new SocialRequest (kind, method, url, paramters, account);
+		}
+
+		#endregion
+
+
+		#region Authentication
+
+		Lazy<ACAccountStore> accountStore = new Lazy<ACAccountStore> (); // Save this reference since ACAccounts are only good so long as it's alive
+
+		/// <summary>
+		/// Gets the account store options passed to Social.framework.
+		/// </summary>
+		protected virtual AccountStoreOptions AccountStoreOptions {
+			get { return null; }
+		}
+
+		public override Task<IEnumerable<Account>> GetAccountsAsync ()
+		{
+			var store = accountStore.Value;
+			var at = store.FindAccountType (this.accountTypeIdentifier);
+			var tcs = new TaskCompletionSource<IEnumerable<Account>> ();
+
+			store.RequestAccess (at, (granted, error) => {
+				if (granted) {
+					var accounts = store.FindAccounts (at)
+						.Select (a => new ACAccountWrapper (a, store))
+						.ToList ();
+
+					tcs.SetResult (accounts);
+				} else {
+					tcs.SetResult (new Account [0]);
+				}
+			});
+
+			return tcs.Task;
+		}
+
+		public override bool SupportsAuthentication
+		{
+			get {
+				return false;
+			}
+		}
+
+		protected override Authenticator GetAuthenticator ()
+		{
+			throw new NotSupportedException ("This service does support authenticating users. You should direct them to the Settings application.");
+		}
+
+		#endregion
+	}
+}

--- a/src/Xamarin.Social.iOS/Services/SocialService.cs
+++ b/src/Xamarin.Social.iOS/Services/SocialService.cs
@@ -177,7 +177,7 @@ namespace Xamarin.Social.Services
 			store.RequestAccess (at, AccountStoreOptions, (granted, error) => {
 				if (granted) {
 					var accounts = store.FindAccounts (at)
-						.Select (a => new ACAccountWrapper (a, store))
+						.Select (a => (Account) new ACAccountWrapper (a, store))
 						.ToList ();
 
 					tcs.SetResult (accounts);

--- a/src/Xamarin.Social.iOS/Services/SocialService.cs
+++ b/src/Xamarin.Social.iOS/Services/SocialService.cs
@@ -174,7 +174,7 @@ namespace Xamarin.Social.Services
 			var at = store.FindAccountType (this.accountTypeIdentifier);
 			var tcs = new TaskCompletionSource<IEnumerable<Account>> ();
 
-			store.RequestAccess (at, (granted, error) => {
+			store.RequestAccess (at, AccountStoreOptions, (granted, error) => {
 				if (granted) {
 					var accounts = store.FindAccounts (at)
 						.Select (a => new ACAccountWrapper (a, store))

--- a/src/Xamarin.Social.iOS/Services/Twitter6Service.cs
+++ b/src/Xamarin.Social.iOS/Services/Twitter6Service.cs
@@ -4,7 +4,7 @@ using MonoTouch.Social;
 
 namespace Xamarin.Social.Services
 {
-	public class Twitter6Service : SocialService
+	public class Twitter6Service : OSSocialService
 	{
 		public Twitter6Service ()
 			: base ("Twitter", "Twitter", SLServiceKind.Twitter, ACAccountType.Twitter)

--- a/src/Xamarin.Social.iOS/Services/Twitter6Service.cs
+++ b/src/Xamarin.Social.iOS/Services/Twitter6Service.cs
@@ -1,0 +1,14 @@
+using System;
+using MonoTouch.Accounts;
+using MonoTouch.Social;
+
+namespace Xamarin.Social.Services
+{
+	public class Twitter6Service : SocialService
+	{
+		public Twitter6Service ()
+			: base ("Twitter", "Twitter", SLServiceKind.Twitter, ACAccountType.Twitter)
+		{
+		}
+	}
+}

--- a/src/Xamarin.Social.iOS/Xamarin.Social.iOS.csproj
+++ b/src/Xamarin.Social.iOS/Xamarin.Social.iOS.csproj
@@ -101,9 +101,9 @@
     <Compile Include="..\..\Xamarin.Auth\src\Xamarin.Auth\WebEx.cs">
       <Link>WebEx.cs</Link>
     </Compile>
-    <Compile Include="Services\SocialService.cs" />
     <Compile Include="Services\Twitter6Service.cs" />
     <Compile Include="Services\Facebook6Service.cs" />
+    <Compile Include="Services\OSSocialService.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Services\" />

--- a/src/Xamarin.Social.iOS/Xamarin.Social.iOS.csproj
+++ b/src/Xamarin.Social.iOS/Xamarin.Social.iOS.csproj
@@ -101,6 +101,9 @@
     <Compile Include="..\..\Xamarin.Auth\src\Xamarin.Auth\WebEx.cs">
       <Link>WebEx.cs</Link>
     </Compile>
+    <Compile Include="Services\SocialService.cs" />
+    <Compile Include="Services\Twitter6Service.cs" />
+    <Compile Include="Services\Facebook6Service.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Services\" />


### PR DESCRIPTION
Add support for iOS 6 Facebook (#7) and Twitter using Social.framework.
The code is mostly based on `Twitter5Service` with minor modifications.

This commit is licensed under MIT/X11.
