### PR TITLE
Implement saving and deleting accounts

### DIFF
--- a/src/Xamarin.Social.iOS/Services/Twitter5Service.cs
+++ b/src/Xamarin.Social.iOS/Services/Twitter5Service.cs
@@ -191,6 +191,26 @@ namespace Xamarin.Social.Services
 		}
 
 		#endregion
+
+		#region Account management
+
+		public override bool SupportsSave {
+			get {
+				return false;
+			}
+		}
+
+		public override void SaveAccount (Account account)
+		{
+			throw new NotSupportedException ("Twitter5Service does support saving user accounts. You should direct them to the Settings application.");
+		}
+
+		public override void DeleteAccount (Account account)
+		{
+			throw new NotSupportedException ("Twitter5Service does support deleting user accounts. You should direct them to the Settings application.");
+		}
+
+		#endregion
 	}
 }
 

--- a/src/Xamarin.Social/Service.cs
+++ b/src/Xamarin.Social/Service.cs
@@ -177,6 +177,55 @@ namespace Xamarin.Social
 #endif
 		#endregion
 
+		#region Account management
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="Xamarin.Social.Service"/> supports saving and deleting accounts.
+		/// </summary>
+		/// <value>
+		/// <c>true</c> if supports saving and deleting accounts; otherwise, <c>false</c>.
+		/// </value>
+		public virtual bool SupportsSave {
+			get {
+				return true;
+			}
+		}
+
+#if PLATFORM_ANDROID
+		/// <summary>
+		/// Saves an account and associates it with this service.
+		/// </summary>
+		public virtual void SaveAccount (Android.Content.Context context, Account account)
+		{
+			AccountStore.Create (context).Save (account, ServiceId);
+		}
+
+		/// <summary>
+		/// Deletes a previously saved account associated with this service.
+		/// </summary>
+		public virtual void DeleteAccount (Android.Content.Context context, Account account)
+		{
+			AccountStore.Create (context).Delete (account, ServiceId);
+		}
+#else
+		/// <summary>
+		/// Saves an account and associates it with this service.
+		/// </summary>
+		public virtual void SaveAccount (Account account)
+		{
+			AccountStore.Create ().Save (account, ServiceId);
+		}
+
+		/// <summary>
+		/// Deletes a previously saved account associated with this service.
+		/// </summary>
+		public virtual void DeleteAccount (Account account)
+		{
+			AccountStore.Create ().Delete (account, ServiceId);
+		}
+#endif
+
+		#endregion
 
 		#region Sharing
 


### PR DESCRIPTION
`DeleteAccount` implements logging out. Our use case
for `SaveAccount` is when your token gets expired, and you
need to save the account with an updated token.

Xamarin.Auth is bumped to the version that contains `AccountStore.Delete`.
Commit licensed under MIT/X11
