### PR TITLE
Add facade for authorization via browser (e.g. Safari)

### DIFF
--- a/src/Xamarin.Social.iOS/Services/Twitter5Service.cs
+++ b/src/Xamarin.Social.iOS/Services/Twitter5Service.cs
@@ -191,6 +191,32 @@ namespace Xamarin.Social.Services
 		}
 
 		#endregion
+
+		#region Account management
+
+		public override bool SupportsSave {
+			get {
+				return false;
+			}
+		}
+
+		public override bool SupportsDelete {
+			get {
+				return false;
+			}
+		}
+
+		public override void SaveAccount (Account account)
+		{
+			throw new NotSupportedException ("Twitter5Service does support saving user accounts. You should direct them to the Settings application.");
+		}
+
+		public override void DeleteAccount (Account account)
+		{
+			throw new NotSupportedException ("Twitter5Service does support deleting user accounts. You should direct them to the Settings application.");
+		}
+
+		#endregion
 	}
 }
 

--- a/src/Xamarin.Social/Service.cs
+++ b/src/Xamarin.Social/Service.cs
@@ -177,6 +177,67 @@ namespace Xamarin.Social
 #endif
 		#endregion
 
+		#region Account management
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="Xamarin.Social.Service"/> supports saving accounts.
+		/// </summary>
+		/// <value>
+		/// <c>true</c> if supports saving accounts; otherwise, <c>false</c>.
+		/// </value>
+		public virtual bool SupportsSave {
+			get {
+				return true;
+			}
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="Xamarin.Social.Service"/> supports deleting accounts.
+		/// </summary>
+		/// <value>
+		/// <c>true</c> if supports deleting accounts; otherwise, <c>false</c>.
+		/// </value>
+		public virtual bool SupportsDelete {
+			get {
+				return true;
+			}
+		}
+
+#if PLATFORM_ANDROID
+		/// <summary>
+		/// Saves an account and associates it with this service.
+		/// </summary>
+		public virtual void SaveAccount (Account account, UIContext context)
+		{
+			AccountStore.Create (context).Save (account, ServiceId);
+		}
+
+		/// <summary>
+		/// Deletes a previously saved account associated with this service.
+		/// </summary>
+		public virtual void DeleteAccount (Account account, UIContext context)
+		{
+			AccountStore.Create (context).Delete (account, ServiceId);
+		}
+#else
+		/// <summary>
+		/// Saves an account and associates it with this service.
+		/// </summary>
+		public virtual void SaveAccount (Account account)
+		{
+			AccountStore.Create ().Save (account, ServiceId);
+		}
+
+		/// <summary>
+		/// Deletes a previously saved account associated with this service.
+		/// </summary>
+		public virtual void DeleteAccount (Account account)
+		{
+			AccountStore.Create ().Delete (account, ServiceId);
+		}
+#endif
+
+		#endregion
 
 		#region Sharing
 


### PR DESCRIPTION
This commit adds facade for authentication via system browser instead of presenting a modal view controller. It includes a working iOS implementation called `SafariUrlHandler`. Android clients [can implement](http://stackoverflow.com/a/2448531/458193) `ICustomUrlHandler` in their code.

This pull request depends on this PR merged in Xamarin.Auth:

https://github.com/xamarin/Xamarin.Auth/pull/31

and this into Xamarin.Social:

https://github.com/xamarin/Xamarin.Social/pull/14

Rationale: we noticed that a lot of people are already logged into Twitter/Facebook in Safari but don't remember / care to enter their passwords when presented with a modal form.

By using this method, we can just take them to Safari, where they are logged in, and then take them back into the app, while reusing `WebRedirectAuthenticator` logic.

![](http://i.imgur.com/zsD62hW.png)

Commit licensed under MIT/X11
