### PR TITLE
Added location support to Twitter and Facebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 bin
 obj
 test-results
-components
-.xpkg
-docs
+src/Components
+samples/
+ components
+ .xpkg
+ docs

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ samples/
  components
  .xpkg
  docs
+StyleCop.Cache

--- a/src/Xamarin.Social.Android/Xamarin.Social.Android.csproj
+++ b/src/Xamarin.Social.Android/Xamarin.Social.Android.csproj
@@ -96,6 +96,9 @@
     <Compile Include="..\..\Xamarin.Auth\src\Xamarin.Auth\WebEx.cs">
       <Link>WebEx.cs</Link>
     </Compile>
+    <Compile Include="..\Xamarin.Social\Location.cs">
+      <Link>Location.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Services\" />

--- a/src/Xamarin.Social.iOS/Xamarin.Social.iOS.csproj
+++ b/src/Xamarin.Social.iOS/Xamarin.Social.iOS.csproj
@@ -105,6 +105,9 @@
     <Compile Include="..\..\Xamarin.Auth\src\Xamarin.Auth\WebEx.cs">
       <Link>WebEx.cs</Link>
     </Compile>
+    <Compile Include="..\Xamarin.Social\Location.cs">
+      <Link>Location.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Services\" />

--- a/src/Xamarin.Social.iOS/Xamarin.Social.iOS.csproj
+++ b/src/Xamarin.Social.iOS/Xamarin.Social.iOS.csproj
@@ -46,7 +46,7 @@
     <Reference Include="System.Json" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Mobile">
-      <HintPath>..\Components\xamarin.mobile-0.7.5\lib\ios-unified\Xamarin.Mobile.dll</HintPath>
+      <HintPath>..\..\..\..\Components\xamarin.mobile-0.7.6\lib\ios-unified\Xamarin.Mobile.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
@@ -120,7 +120,7 @@
   </ItemGroup>
   <ItemGroup>
     <XamarinComponentReference Include="xamarin.mobile">
-      <Version>0.7.5</Version>
+      <Version>0.7.6</Version>
       <Visible>False</Visible>
     </XamarinComponentReference>
   </ItemGroup>

--- a/src/Xamarin.Social.iOS/Xamarin.Social.iOS.csproj
+++ b/src/Xamarin.Social.iOS/Xamarin.Social.iOS.csproj
@@ -10,6 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Social</RootNamespace>
     <AssemblyName>Xamarin.Social.iOS</AssemblyName>
+    <SynchReleaseVersion>false</SynchReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/src/Xamarin.Social/Item.cs
+++ b/src/Xamarin.Social/Item.cs
@@ -124,19 +124,19 @@ namespace Xamarin.Social
 		/// </summary>
 		public IList<FileData> Files { get; set; }
 
-		private Location _location = null;
+        private Location location = null;
 		/// <summary>
 		/// Gets or sets the location associated with this item.
 		/// </summary>
 		public Location Location { 
 			get {
-				if (_location == null) {
-					_location = new Location ();
+				if (location == null) {
+					location = new Location ();
 				}
-				return _location;
+				return location;
 			} 
 			set {
-				_location = value;
+				location = value;
 			}
 		}
 

--- a/src/Xamarin.Social/Item.cs
+++ b/src/Xamarin.Social/Item.cs
@@ -124,6 +124,22 @@ namespace Xamarin.Social
 		/// </summary>
 		public IList<FileData> Files { get; set; }
 
+		private Location _location = null;
+		/// <summary>
+		/// Gets or sets the location associated with this item.
+		/// </summary>
+		public Location Location { 
+			get {
+				if (_location == null) {
+					_location = new Location ();
+				}
+				return _location;
+			} 
+			set {
+				_location = value;
+			}
+		}
+
 #if SUPPORT_VIDEO
 		/// <summary>
 		/// Attached video.

--- a/src/Xamarin.Social/Location.cs
+++ b/src/Xamarin.Social/Location.cs
@@ -1,0 +1,31 @@
+//
+//   Copyright 2013, Michael Henke
+//
+//     Licensed under the Apache License, Version 2.0 (the "License");
+//     you may not use this file except in compliance with with the License.
+//     You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+//
+using System;
+
+namespace Xamarin.Social
+{
+	public class Location
+	{
+		public double Latitude { get; set; }
+
+		public double Longitude { get; set; }
+
+		public Location ()
+		{
+		}
+	}
+}
+

--- a/src/Xamarin.Social/Services/FacebookService.cs
+++ b/src/Xamarin.Social/Services/FacebookService.cs
@@ -124,6 +124,10 @@ namespace Xamarin.Social.Services
 					message.Append (l.AbsoluteUri);
 				}
 				req.AddMultipartData ("message", message.ToString ());
+				if (placeId != null) {
+
+					req.AddMultipartData("place", placeId);
+				}
 			}
 			else {
 				req = CreateRequest ("POST", new Uri ("https://graph.facebook.com/me/feed"), account);

--- a/src/Xamarin.Social/Services/FacebookService.cs
+++ b/src/Xamarin.Social/Services/FacebookService.cs
@@ -101,10 +101,19 @@ namespace Xamarin.Social.Services
 			} 
 			else
 			{
-				await ShareItemWithLocationAsync(item, account, null, cancellationToken).ContinueWith(reqTask => {
+                try
+                {
+    				await ShareItemWithLocationAsync(item, account, null, cancellationToken).ContinueWith(reqTask => {
 
-					return reqTask;
-				});
+    					return reqTask;
+    				});
+                }
+                catch(Exception e)
+                {
+                    #if DEBUG
+                    throw(e);
+                    #endif
+                }
 			}
 		}
 
@@ -146,7 +155,7 @@ namespace Xamarin.Social.Services
 				if (!content.Contains ("\"id\"")) {
 					throw new SocialException ("Facebook returned an unrecognized response.");
 				}
-			});
+            });
 		}
 	}
 }

--- a/src/Xamarin.Social/Services/FacebookService.cs
+++ b/src/Xamarin.Social/Services/FacebookService.cs
@@ -89,24 +89,22 @@ namespace Xamarin.Social.Services
 				placeRequest.Parameters ["center"] = item.Location.Latitude.ToString() + "," + item.Location.Longitude.ToString();
 				placeRequest.Parameters ["distance"] = "100";
 
-				await placeRequest.GetResponseAsync(cancellationToken).ContinueWith(reqTask => {
-					var obj = JsonObject.Parse(reqTask.Result.GetResponseText());
+                var reqTask = await placeRequest.GetResponseAsync(cancellationToken).ConfigureAwait(false);
 
-					if (obj.ContainsKey("data") && obj["data"].Count > 0 && obj["data"][0].ContainsKey("id"))
-						placeId = obj ["data"] [0] ["id"];
+                var obj = JsonObject.Parse(reqTask.GetResponseText());
 
-					return ShareItemWithLocationAsync(item, account, placeId, cancellationToken);
-				});
-				;
+				if (obj.ContainsKey("data") && obj["data"].Count > 0 && obj["data"][0].ContainsKey("id"))
+					placeId = obj ["data"] [0] ["id"];
+
+                await ShareItemWithLocationAsync(item, account, placeId, cancellationToken).ConfigureAwait(false);
+
+                return;
 			} 
 			else
 			{
                 try
                 {
-    				await ShareItemWithLocationAsync(item, account, null, cancellationToken).ContinueWith(reqTask => {
-
-    					return reqTask;
-    				});
+                    await ShareItemWithLocationAsync(item, account, null, cancellationToken).ConfigureAwait(false);
                 }
                 catch(Exception e)
                 {
@@ -114,6 +112,7 @@ namespace Xamarin.Social.Services
                     throw(e);
                     #endif
                 }
+                return;
 			}
 		}
 

--- a/src/Xamarin.Social/Services/TwitterService.cs
+++ b/src/Xamarin.Social/Services/TwitterService.cs
@@ -23,6 +23,8 @@ using System.Text;
 using System.Linq;
 using Xamarin.Auth;
 
+using MonoTouch.CoreLocation;
+
 namespace Xamarin.Social.Services
 {
 	public class TwitterService : OAuth1Service
@@ -71,10 +73,18 @@ namespace Xamarin.Social.Services
 			if (item.Images.Count == 0) {
 				req = CreateRequest ("POST", new Uri ("https://api.twitter.com/1.1/statuses/update.json"), account);
 				req.Parameters["status"] = status;
+				if (item.Location.Latitude != 0 && item.Location.Longitude != 0) {
+					req.Parameters ["lat"] = item.Location.Latitude.ToString();
+					req.Parameters ["long"] = item.Location.Longitude.ToString();
+				}
 			}
 			else {
 				req = CreateRequest ("POST", new Uri ("https://api.twitter.com/1.1/statuses/update_with_media.json"), account);
 				req.AddMultipartData ("status", status);
+				if (item.Location.Latitude != 0 && item.Location.Longitude != 0) {
+					req.AddMultipartData ("lat", item.Location.Latitude.ToString());
+					req.AddMultipartData ("long", item.Location.Longitude.ToString());
+				}
 				foreach (var i in item.Images.Take (MaxImages)) {
 					i.AddToRequest (req, "media[]");
 				}

--- a/src/Xamarin.Social/Services/TwitterService.cs
+++ b/src/Xamarin.Social/Services/TwitterService.cs
@@ -23,8 +23,6 @@ using System.Text;
 using System.Linq;
 using Xamarin.Auth;
 
-using MonoTouch.CoreLocation;
-
 namespace Xamarin.Social.Services
 {
 	public class TwitterService : OAuth1Service

--- a/src/Xamarin.Social/Xamarin.Social.csproj
+++ b/src/Xamarin.Social/Xamarin.Social.csproj
@@ -77,6 +77,7 @@
     <Compile Include="..\..\Xamarin.Auth\src\Xamarin.Auth\WebEx.cs">
       <Link>WebEx.cs</Link>
     </Compile>
+    <Compile Include="Location.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />


### PR DESCRIPTION
Hi,

I'd like to use Xamarin.Social for sharing pictures from a camera component in an app. I noticed that it yet lacks location support. I added my humble idea of location support and would like some input. 
- I was only able to test it on iOS (6 & 7) for lack of an actual Android test device and license.
- I would like to add it to App.net as well but am not yet ready to invest $100 for the developer account just yet.

The way it currently works is, that the app determines it's location and assigns lat and long values to the Location property of the item. If the values are set, we pass them verbatim to the Twitter Api. For Facebook we have to find a place_id first. An additional request is necessary for this. I imagine the API for App.net being similar to Twitter in this regard.

michael
